### PR TITLE
Add a Dockerfile to build symengine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ services:
 before_install:
   - docker build -t symengine/ubuntu_base ./ubuntu_base
   - docker build -t symengine/conda_base ./conda_base
+  - docker build -t symengine/symengine ./symengine
 
 script:
   - docker run symengine/ubuntu_base id
   - docker run symengine/conda_base id
+  - docker run symengine/symengine symengine/benchmarks/expand2
 
 notifications:
   email: false

--- a/symengine/Dockerfile
+++ b/symengine/Dockerfile
@@ -1,0 +1,13 @@
+FROM symengine/ubuntu_base
+
+RUN sudo apt-get update && DEBIAN_FRONTEND=noninteractive \
+    sudo apt-get install -yq --no-install-recommends \
+        git cmake make g++ libgmp-dev \
+    && sudo apt-get clean \
+    && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && hash -r
+
+RUN GIT_SSL_NO_VERIFY=true git clone https://github.com/symengine/symengine && \
+    cd symengine && \
+    cmake . && \
+    make


### PR DESCRIPTION
This builds a symengine docker image and executes a benchmark on Travis.